### PR TITLE
Fix CORS for www WB6 origins

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -28,7 +28,13 @@ app = FastAPI()
 # ── CORS ──────────────────────────────────────
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["https://wb6.ru", "https://wb6.vercel.app"],
+    allow_origins=[
+        "https://wb6.ru",
+        "http://wb6.ru",
+        "https://www.wb6.ru",
+        "http://www.wb6.ru",
+        "https://wb6.vercel.app",
+    ],
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,4 +3,5 @@ uvicorn
 openai
 python-dotenv
 PyJWT
+httpx<0.28
 

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,26 @@
+import os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+from fastapi.testclient import TestClient
+from main import app
+import pytest
+
+client = TestClient(app)
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "http://wb6.ru",
+        "https://www.wb6.ru",
+        "http://www.wb6.ru",
+    ],
+)
+def test_wb6_origins_allowed(origin):
+    resp = client.options(
+        "/rewrite",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == origin


### PR DESCRIPTION
## Summary
- include both HTTP and HTTPS `www.wb6.ru` in allowed CORS origins
- parametrize CORS regression test for all `wb6.ru` hostnames
- pin `httpx<0.28` in backend requirements to support Starlette test client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879a35f98d08333bebfc234557fb38f