### PR TITLE
Handle env secrets properly

### DIFF
--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,5 +1,8 @@
 import os, sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+# Ensure required env vars for import
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("ENV", "DEV")
 from fastapi.testclient import TestClient
 from main import app
 import pytest

--- a/tests/test_env_vars.py
+++ b/tests/test_env_vars.py
@@ -1,0 +1,42 @@
+import os, sys, importlib
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+
+
+def reload_main():
+    if 'main' in sys.modules:
+        del sys.modules['main']
+    return importlib.import_module('main')
+
+
+def test_missing_openai_key(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    with pytest.raises(ValueError):
+        reload_main()
+
+
+def test_dev_placeholders(monkeypatch, caplog):
+    monkeypatch.setenv('OPENAI_API_KEY', 'key')
+    monkeypatch.delenv('ROBOKASSA_PASS2', raising=False)
+    monkeypatch.delenv('JWT_SECRET', raising=False)
+    monkeypatch.setenv('ENV', 'DEV')
+    caplog.set_level('WARNING')
+    m = reload_main()
+    assert m.PASS2 == 'dev-pass2'
+    assert len(m.SECRET) >= 32
+    assert 'ROBOKASSA_PASS2' in caplog.text
+    assert 'JWT_SECRET' in caplog.text
+
+
+def test_production_no_placeholders(monkeypatch, caplog):
+    monkeypatch.setenv('OPENAI_API_KEY', 'key')
+    monkeypatch.delenv('ROBOKASSA_PASS2', raising=False)
+    monkeypatch.delenv('JWT_SECRET', raising=False)
+    monkeypatch.setenv('ENV', 'PRODUCTION')
+    caplog.set_level('WARNING')
+    m = reload_main()
+    assert m.PASS2 is None
+    assert m.SECRET is None
+    assert 'ROBOKASSA_PASS2' in caplog.text
+    assert 'JWT_SECRET' in caplog.text


### PR DESCRIPTION
## Summary
- load secrets from environment and raise when OPENAI_API_KEY is missing
- log warnings and generate dev placeholders for missing ROBOKASSA_PASS2 and JWT_SECRET
- make existing CORS tests set env vars
- add unit tests for env vars behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ad6179b388333a9ed2de0c50aa5f1