### PR TITLE
Fix Robokassa signature and add test

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -139,8 +139,10 @@ async def rewrite(r:Req, request:Request):
 @app.post("/payhook")
 async def payhook(req:Request):
     f = await req.form()
-    crc = hashlib.md5(f"{f['InvId']}:{f['OutSum']}:{PASS2}:shp={f['Shp_plan']}".encode()).hexdigest().upper()
-    if crc != f['SignatureValue'].upper(): return "bad sign"
+    crc_str = f"{f['OutSum']}:{f['InvId']}:{PASS2}:Shp_plan={f['Shp_plan']}"
+    crc = hashlib.md5(crc_str.encode()).hexdigest().upper()
+    if crc != f['SignatureValue'].upper():
+        return "bad sign"
     quota = 15 if f['Shp_plan']=="15" else 60
     email = f.get("Email", "user@wb6")
     create_account(email, quota, f['InvId'])

--- a/tests/test_payhook.py
+++ b/tests/test_payhook.py
@@ -1,0 +1,25 @@
+import os, sys, importlib, hashlib
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+
+def reload_main():
+    if 'main' in sys.modules:
+        del sys.modules['main']
+    return importlib.import_module('main')
+
+
+def test_payhook_crc(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'key')
+    monkeypatch.setenv('ROBOKASSA_PASS2', 'pass2')
+    app = reload_main().app
+    from fastapi.testclient import TestClient
+    client = TestClient(app)
+    data = {'InvId': '1', 'OutSum': '199', 'Shp_plan': '15'}
+    crc_str = f"{data['OutSum']}:{data['InvId']}:pass2:Shp_plan=15"
+    data['SignatureValue'] = hashlib.md5(crc_str.encode()).hexdigest().upper()
+    resp = client.post('/payhook', data=data)
+    assert resp.json() == 'OK'
+
+    data['SignatureValue'] = 'BAD'
+    resp = client.post('/payhook', data=data)
+    assert resp.json() == 'bad sign'


### PR DESCRIPTION
## Summary
- correct signature calculation in `/payhook`
- add regression test for Robokassa CRC verification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c461847e8833381fb8e5b7beea970