### PR TITLE
Fix Robokassa signature parameter ordering

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -140,7 +140,10 @@ async def rewrite(r:Req, request:Request):
 async def payhook(req:Request):
     f = await req.form()
     inv = f.get("InvId") or f.get("InvoiceID")
-    crc_str = f"{f['OutSum']}:{inv}:{PASS2}:Shp_plan={f['Shp_plan']}"
+    # Collect and sort all Shp_* parameters alphabetically for CRC
+    shp_params = {k: f[k] for k in f.keys() if k.startswith('Shp_')}
+    shp_part = ':'.join(f"{k}={shp_params[k]}" for k in sorted(shp_params))
+    crc_str = f"{f['OutSum']}:{inv}:{PASS2}:{shp_part}"
     crc = hashlib.md5(crc_str.encode()).hexdigest().upper()
     if crc != f['SignatureValue'].upper():
         return "bad sign"

--- a/frontend/pay.html
+++ b/frontend/pay.html
@@ -33,7 +33,13 @@ form.onsubmit = e => {
   const inv = Date.now();
   const desc = plan.value + ' rewrite';
 
-  const crcStr = `${LOGIN}:${price}:${inv}:${PASS1}:Shp_plan=${plan.value}`;
+  // Sort all Shp_* params before signing as required by Robokassa
+  const shpParams = { Shp_plan: plan.value };
+  const shpPart = Object.keys(shpParams)
+    .sort()
+    .map(k => `${k}=${shpParams[k]}`)
+    .join(':');
+  const crcStr = `${LOGIN}:${price}:${inv}:${PASS1}:${shpPart}`;
   const sig = CryptoJS.MD5(crcStr).toString();
 
   const paymentForm = document.createElement('form');

--- a/tests/test_payhook.py
+++ b/tests/test_payhook.py
@@ -15,7 +15,9 @@ def test_payhook_crc(monkeypatch):
     from fastapi.testclient import TestClient
     client = TestClient(app)
     data = {'InvId': '1', 'OutSum': '199', 'Shp_plan': '15'}
-    crc_str = f"{data['OutSum']}:{data['InvId']}:pass2:Shp_plan=15"
+    shp_params = {k: data[k] for k in data if k.startswith('Shp_')}
+    shp_part = ':'.join(f"{k}={shp_params[k]}" for k in sorted(shp_params))
+    crc_str = f"{data['OutSum']}:{data['InvId']}:pass2:{shp_part}"
     data['SignatureValue'] = hashlib.md5(crc_str.encode()).hexdigest().upper()
     resp = client.post('/payhook', data=data)
     assert resp.json() == 'OK'


### PR DESCRIPTION
## Summary
- ensure Shp_* parameters are sorted when generating CRC on frontend
- match Robokassa signature verification on backend
- adjust unit test for new CRC procedure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cfdd3873083339a127b5ac0bdac2c