### PR TITLE
Integrate contact scraping workflow

### DIFF
--- a/.github/workflows/collect_social.yml
+++ b/.github/workflows/collect_social.yml
@@ -1,10 +1,8 @@
 name: Collect Socials
 on:
-  workflow_dispatch:
-    inputs:
-      keyword:
-        description: 'Keyword for seller search'
-        required: true
+  push:
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   collect:
     runs-on: ubuntu-latest
@@ -16,18 +14,10 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r backend/requirements.txt
-          pip install tqdm
+          pip install tqdm beautifulsoup4
       - name: Search seller ids
-        run: python utils/search_scraper.py --query "${{ github.event.inputs.keyword }}" --output raw_sellers.csv
+        run: python utils/search_scraper.py --query "шапка" --pages 3 --output raw_sellers.csv
       - name: Collect social links
-        run: python utils/social_scraper.py --input raw_sellers.csv --output socials.csv
-      - name: Validate result
-        run: |
-          python - <<'PY'
-import csv, sys
-rows=list(csv.DictReader(open('socials.csv', encoding='utf-8')))
-count=sum(1 for r in rows if r.get('telegram') or r.get('whatsapp'))
-print('rows with contacts:', count)
-if count<=0:
-    sys.exit('No contacts found')
-PY
+        run: python utils/social_scraper.py --input raw_sellers.csv --output contacts.csv
+      - name: Validate contacts
+        run: grep -q "@" contacts.csv

--- a/README.md
+++ b/README.md
@@ -67,3 +67,15 @@ WB6 — это веб-сервис, который с помощью OpenAI пе
 - [ ] Task#3: unit test for Robokassa signature
 - [ ] Task#4: cron daily-report → Telegram
 - [ ] Task#5: add usage endpoint `/usage`
+
+## Сбор контактов
+
+1. Запустите поиск продавцов:
+   ```bash
+   python utils/search_scraper.py --query "шапка" --pages 3 --output raw_sellers.csv
+   ```
+2. Для каждого supplier_id подтяните соцсети:
+   ```bash
+   python utils/social_scraper.py --input raw_sellers.csv --output contacts.csv
+   ```
+   Итоговый `contacts.csv` содержит столбцы `supplier_id`, `telegram`, `whatsapp`.

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -7,8 +7,11 @@ class FakeResp:
         self.text = text
 
 def test_social_links(monkeypatch, tmp_path):
-    html = '<a href="https://t.me/test">tg</a> <a href="https://wa.me/123">wa</a>'
-    monkeypatch.setattr(ss.S, 'get', lambda url: FakeResp(html))
+    html = (
+        '<a href="https://t.me/testseller">tg</a> '
+        '<a href="https://wa.me/71234567890">wa</a>'
+    )
+    monkeypatch.setattr(ss.requests, "get", lambda url, **kw: FakeResp(html))
     monkeypatch.setattr(ss.time, 'sleep', lambda x: None)
     input_csv = tmp_path / 'raw.csv'
     with open(input_csv, 'w', newline='', encoding='utf-8') as f:
@@ -19,5 +22,5 @@ def test_social_links(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, 'argv', argv)
     ss.main()
     rows = list(csv.DictReader(open(output_csv, encoding='utf-8')))
-    assert rows[0]['telegram'] == 'https://t.me/test'
-    assert rows[0]['whatsapp'] == 'https://wa.me/123'
+    assert rows[0]['telegram'] == 'https://t.me/testseller'
+    assert rows[0]['whatsapp'] == 'https://wa.me/71234567890'

--- a/utils/search_scraper.py
+++ b/utils/search_scraper.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
-"""
-search_scraper.py  –  собирает seller_id по ключевому слову (Wildberries search API)
-пример:
+"""search_scraper.py
+Собирает supplier_id по ключевому слову через Wildberries search API.
+Версия: 2025-07-22
+
+Пример запуска:
     python search_scraper.py --query "шапка" --pages 10 --output raw_sellers.csv
 """
 

--- a/utils/social_scraper.py
+++ b/utils/social_scraper.py
@@ -3,36 +3,54 @@ import csv, re, time, argparse, requests
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
-HEAD = {"User-Agent":"Mozilla/5.0 (X11; Linux) Chrome/126 Safari/537.36"}
-TG_RE = re.compile(r'(https?://t\.me/[A-Za-z0-9_]+|@[A-Za-z0-9_]{4,})', re.I)
-WA_RE = re.compile(r'https?://(?:wa\.me|api\.whatsapp\.com)/\d+', re.I)
-S = requests.Session(); S.headers.update(HEAD); S.timeout=10
+HEAD = {"User-Agent": "Mozilla/5.0 (X11; Linux) Chrome/126 Safari/537.36"}
+TG_RE = re.compile(
+    r"(https?://t\.me/[A-Za-z0-9_]+|tg://resolve\?domain=[A-Za-z0-9_]+|@[A-Za-z0-9_]{4,})",
+    re.I,
+)
+WA_RE = re.compile(
+    r"https?://(?:wa\.me|api\.whatsapp\.com)/\d+|whatsapp://send\?phone=\d+",
+    re.I,
+)
 
-def parse(html:str):
-    soup=BeautifulSoup(html,'html.parser'); t=soup.get_text(' ',strip=True)
-    tg=TG_RE.search(t); wa=WA_RE.search(t)
-    for a in soup.find_all('a',href=True):
-        if not tg and TG_RE.search(a['href']): tg=TG_RE.search(a['href'])
-        if not wa and WA_RE.search(a['href']): wa=WA_RE.search(a['href'])
-    return (tg.group(0) if tg else '', wa.group(0) if wa else '')
+def parse(html: str) -> tuple[str, str]:
+    soup = BeautifulSoup(html, "html.parser")
+    text = soup.get_text(" ", strip=True)
+    tg = TG_RE.search(text)
+    wa = WA_RE.search(text)
+    for a in soup.find_all("a", href=True):
+        if not tg and TG_RE.search(a["href"]):
+            tg = TG_RE.search(a["href"])
+        if not wa and WA_RE.search(a["href"]):
+            wa = WA_RE.search(a["href"])
+    return (tg.group(0) if tg else "", wa.group(0) if wa else "")
 
 def main():
-    ap=argparse.ArgumentParser()
-    ap.add_argument('--input',default='raw_sellers.csv')
-    ap.add_argument('--output',default='socials.csv')
-    ap.add_argument('--delay',type=float,default=.15)
-    a=ap.parse_args()
-    rows=list(csv.DictReader(open(a.input,newline='',encoding='utf-8')))
-    fn=list(rows[0].keys())+['telegram','whatsapp']
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", default="raw_sellers.csv")
+    ap.add_argument("--output", default="contacts.csv")
+    ap.add_argument("--delay", type=float, default=0.15)
+    a = ap.parse_args()
+
+    rows = list(csv.DictReader(open(a.input, newline="", encoding="utf-8")))
+    fn = list(rows[0].keys()) + ["telegram", "whatsapp"]
+
     for r in tqdm(rows):
         try:
-            h=S.get(f"https://www.wildberries.ru/seller/{r['supplier_id']}").text
-            r['telegram'],r['whatsapp']=parse(h)
-        except: r['telegram']=r['whatsapp']=''
+            resp = requests.get(
+                f"https://www.wildberries.ru/seller/{r['supplier_id']}",
+                headers=HEAD,
+                timeout=10,
+            )
+            r["telegram"], r["whatsapp"] = parse(resp.text)
+        except Exception:
+            r["telegram"] = r["whatsapp"] = ""
         time.sleep(a.delay)
-    csv.DictWriter(open(a.output,'w',newline='',encoding='utf-8'),fieldnames=fn)\
-        .writeheader(); csv.writer(open(a.output,'a',newline='',encoding='utf-8'))\
-        .writerows([r.values() for r in rows])
-    print("Done:",a.output)
+
+    with open(a.output, "w", newline="", encoding="utf-8") as f:
+        csv.DictWriter(f, fieldnames=fn).writeheader()
+        csv.writer(f).writerows([r.values() for r in rows])
+    print("Done:", a.output)
+
 if __name__=='__main__': main()
 


### PR DESCRIPTION
## Summary
- update social scraper to fetch seller pages directly via `requests.get`
- add contact scraping workflow that runs on pushes and daily
- document contact harvesting in README
- update unit test for contact scraper
- note search scraper version info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687feeec031c83339a4e789a882aa587