### PR TITLE
fix(scraper): use create_scraper from aiocfscrape

### DIFF
--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -15,7 +15,10 @@ class DummyScraper:
     async def get(self, url, headers=None, timeout=10):
         return ""
 
-sys.modules['aiocfscrape'] = types.SimpleNamespace(AsyncCloudflareScraper=DummyScraper)
+async def create_scraper():
+    return DummyScraper()
+
+sys.modules['aiocfscrape'] = types.SimpleNamespace(create_scraper=create_scraper)
 import social_scraper as ss
 
 

--- a/utils/social_scraper.py
+++ b/utils/social_scraper.py
@@ -46,7 +46,7 @@ async def fetch(session:aiohttp.ClientSession, url:str, timeout:int=15)->str:
 async def get_inn_cf(sid:str, scraper)->str:
     url = f'https://www.wildberries.ru/seller/{sid}'
     try:
-        html = await scraper.get(url, headers=HEADERS, timeout=15)
+        html = await (await scraper.get(url, headers=HEADERS, timeout=15)).text()
         m = INN_RE.search(html)
         return m.group(1) if m else ''
     except Exception:
@@ -98,7 +98,7 @@ async def run(args):
     sem = asyncio.Semaphore(args.concurrency)
     state = {'fns':0}
 
-    async with aiohttp.ClientSession() as session, aiocfscrape.AsyncCloudflareScraper() as scraper:
+    async with aiohttp.ClientSession() as session, await aiocfscrape.create_scraper() as scraper:
         tasks = [process(r, session, scraper, sem, args, state) for r in rows]
         done  = await tqdm.gather(*tasks, ncols=80, desc='Scraping')
 


### PR DESCRIPTION
## Summary
- use `create_scraper` in `social_scraper` to instantiate AsyncCloudflareScraper
- adjust `get_inn_cf` to await the response text
- update tests to mock `create_scraper`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688345c510588333b3481ce0edc1360b