### PR TITLE
Add SQLite storage for tokens and sequential invoices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 **/__pycache__/
 
+backend/tokens.db

--- a/frontend/pay.html
+++ b/frontend/pay.html
@@ -25,13 +25,13 @@ const PASS1 = "EyQbM1TFm6uOp6l6JEi2"; // пароль#1 из кабинета
 const LOGIN = "wb6.ru"; // MrchLogin
 const TEST_MODE = !location.hostname.match(/^wb6\.ru$/);
 const form = document.getElementById('pay');
-form.onsubmit = e => {
+form.onsubmit = async e => {
   e.preventDefault();
 
   const plan = document.getElementById('plan');
   const email = document.getElementById('email').value;
   const price = plan.options[plan.selectedIndex].dataset.price;
-  const inv = Date.now();
+  const inv = (await fetch('https://api.wb6.ru/next_inv').then(r => r.json())).inv;
   const desc = plan.value + ' rewrite';
 
   // Sort all Shp_* params before signing as required by Robokassa

--- a/tests/test_payhook.py
+++ b/tests/test_payhook.py
@@ -25,3 +25,26 @@ def test_payhook_crc(monkeypatch):
     data['SignatureValue'] = 'BAD'
     resp = client.post('/payhook', data=data)
     assert resp.json() == 'bad sign'
+
+
+def test_paytoken_persistence(monkeypatch, tmp_path):
+    monkeypatch.setenv('OPENAI_API_KEY', 'key')
+    monkeypatch.setenv('ROBOKASSA_PASS2', 'pass2')
+    monkeypatch.setenv('TOKENS_DB', str(tmp_path / 'tok.db'))
+
+    m = reload_main()
+    from fastapi.testclient import TestClient
+    client = TestClient(m.app)
+    data = {'InvId': '42', 'OutSum': '199', 'Shp_plan': '15'}
+    shp_params = {k: data[k] for k in data if k.startswith('Shp_')}
+    shp_part = ':'.join(f"{k}={shp_params[k]}" for k in sorted(shp_params))
+    crc_str = f"{data['OutSum']}:{data['InvId']}:pass2:{shp_part}"
+    data['SignatureValue'] = hashlib.md5(crc_str.encode()).hexdigest().upper()
+    client.post('/payhook', data=data)
+
+    m2 = reload_main()
+    client2 = TestClient(m2.app)
+    resp = client2.get('/paytoken', params={'inv': data['InvId']})
+    assert 'token' in resp.json()
+    resp2 = client2.get('/paytoken', params={'inv': data['InvId']})
+    assert resp2.json()['error'] == 'NOT_READY'


### PR DESCRIPTION
## Summary
- persist Robokassa tokens in `tokens.db`
- provide sequential invoice numbers starting from 3000
- store token in DB on `/payhook` and return it from `/paytoken`
- new endpoint `/next_inv`
- frontend uses `/next_inv` to get invoice id
- test persistence across reloads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883ec1609a0833393b6b1df119ceeec