### PR TITLE
Show RK creds on pay_test page

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -45,6 +45,9 @@ if not PASS2:
     if not PROD:
         PASS2 = "dev-pass2"
 
+# Формула контрольной суммы платежной формы
+CRC_FORMULA = "md5(MerchantLogin:OutSum:InvId:Pass1:Shp_plan=PLAN)"
+
 # ✅ JWT-секрет (подписывает access-токены на клиенте)
 SECRET = os.getenv("JWT_SECRET")
 if not SECRET:
@@ -272,6 +275,12 @@ async def login(r: LoginReq):
 @app.get("/next_inv")
 async def get_next_inv():
     return {"inv": next_inv_id()}
+
+
+# Информация для тестовой страницы Robokassa
+@app.get("/rkinfo")
+async def rkinfo():
+    return {"pass1": PASS1, "pass2": PASS2, "crc_formula": CRC_FORMULA}
 
 
 @app.post("/payform")

--- a/frontend/pay_test.html
+++ b/frontend/pay_test.html
@@ -20,6 +20,7 @@
   </label>
   <button type="submit">Оплатить</button>
 </form>
+<pre id="rkinfo"></pre>
 <script>
 const form = document.getElementById('pay');
 form.onsubmit = async e => {
@@ -42,6 +43,16 @@ form.onsubmit = async e => {
   // document.body.appendChild(rkForm);       // TEST: append if needed
   // document.getElementById('rk').submit();  // TEST: auto-submit disabled
 };
+
+// Показать pass1/pass2 и формулу CRC
+fetch('https://api.wb6.ru/rkinfo')
+  .then(r => r.json())
+  .then(js => {
+    document.getElementById('rkinfo').textContent =
+      'Pass1: ' + js.pass1 + '\n' +
+      'Pass2: ' + js.pass2 + '\n' +
+      'CRC: ' + js.crc_formula;
+  });
 
 // автозагрузка токена после оплаты
 const q = new URLSearchParams(location.search);

--- a/tests/test_rkinfo.py
+++ b/tests/test_rkinfo.py
@@ -1,0 +1,23 @@
+import os, sys, importlib
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+
+
+def reload_main():
+    if 'main' in sys.modules:
+        del sys.modules['main']
+    return importlib.import_module('main')
+
+
+def test_rkinfo(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'key')
+    monkeypatch.setenv('ROBOKASSA_PASS1', 'p1')
+    monkeypatch.setenv('ROBOKASSA_PASS2', 'p2')
+    app = reload_main().app
+    from fastapi.testclient import TestClient
+    client = TestClient(app)
+    resp = client.get('/rkinfo')
+    js = resp.json()
+    assert js['pass1'] == 'p1'
+    assert js['pass2'] == 'p2'
+    assert 'crc_formula' in js


### PR DESCRIPTION
## Summary
- add constant `CRC_FORMULA` and new `/rkinfo` endpoint exposing Robokassa Pass1/Pass2
- display Robokassa passwords and CRC formula on `pay_test.html`
- cover new endpoint with `test_rkinfo`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884becad98c8333adf62bc20e4a39a4