### PR TITLE
Disable Desc and Email in payform

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -309,12 +309,9 @@ async def payform(request: Request):
         "MerchantLogin": LOGIN,
         "OutSum": price,
         "InvId": inv,
-        "Desc": desc,
         "SignatureValue": sig,
     }
     fields.update(shp_params)
-    if email:
-        fields["Email"] = email
     html = [
         '<form method="POST" action="https://auth.robokassa.ru/Merchant/Index.aspx" id="rk">'
     ]

--- a/tests/test_payform.py
+++ b/tests/test_payform.py
@@ -33,5 +33,5 @@ def test_payform_crc(monkeypatch):
     shp_part = ":".join(f"{k}={shp_params[k]}" for k in sorted(shp_params))
     crc_str = f"{fields['MerchantLogin']}:{fields['OutSum']}:{fields['InvId']}:pass1:{shp_part}"
     assert fields["SignatureValue"] == hashlib.md5(crc_str.encode()).hexdigest()
-    assert "Desc" in fields
-    assert "Email" in fields
+    assert "Desc" not in fields
+    assert "Email" not in fields


### PR DESCRIPTION
## Summary
- stop including `Desc` and `Email` in Robokassa form
- adjust tests to expect those fields to be absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884dadddc08833394109905c316c28c