### PR TITLE
Fix Robokassa crc formula

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -302,7 +302,9 @@ async def payform(request: Request):
             shp_params[k] = str(v)
 
     shp_part = ":".join(f"{k}={shp_params[k]}" for k in sorted(shp_params))
-    crc_str = f"{LOGIN}:{price}:{inv}:{PASS1}:{shp_part}"
+    crc_str = f"{LOGIN}:{price}:{inv}:{PASS1}"
+    if shp_part:
+        crc_str += f":{shp_part}"
     sig = hashlib.md5(crc_str.encode()).hexdigest()
 
     fields = {

--- a/tests/test_payform.py
+++ b/tests/test_payform.py
@@ -31,7 +31,9 @@ def test_payform_crc(monkeypatch):
 
     shp_params = {k: fields[k] for k in fields if k.startswith("Shp_")}
     shp_part = ":".join(f"{k}={shp_params[k]}" for k in sorted(shp_params))
-    crc_str = f"{fields['MerchantLogin']}:{fields['OutSum']}:{fields['InvId']}:pass1:{shp_part}"
+    crc_str = f"{fields['MerchantLogin']}:{fields['OutSum']}:{fields['InvId']}:pass1"
+    if shp_part:
+        crc_str += f":{shp_part}"
     assert fields["SignatureValue"] == hashlib.md5(crc_str.encode()).hexdigest()
     assert "Desc" not in fields
     assert "Email" not in fields


### PR DESCRIPTION
## Summary
- update /payform crc string logic so `:Shp_` section is optional
- adjust CRC test to mirror updated formula

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884eb1a69f88333a245d7f90595c3b7