### PR TITLE
Remove Shp_plan from payment flow

### DIFF
--- a/tests/test_payform.py
+++ b/tests/test_payform.py
@@ -37,3 +37,4 @@ def test_payform_crc(monkeypatch):
     assert fields["SignatureValue"] == hashlib.md5(crc_str.encode()).hexdigest()
     assert "Desc" not in fields
     assert "Email" not in fields
+    assert "Shp_plan" not in fields

--- a/tests/test_payhook.py
+++ b/tests/test_payhook.py
@@ -14,10 +14,12 @@ def test_payhook_crc(monkeypatch):
     app = reload_main().app
     from fastapi.testclient import TestClient
     client = TestClient(app)
-    data = {'InvId': '1', 'OutSum': '199', 'Shp_plan': '15'}
+    data = {'InvId': '1', 'OutSum': '199'}
     shp_params = {k: data[k] for k in data if k.startswith('Shp_')}
     shp_part = ':'.join(f"{k}={shp_params[k]}" for k in sorted(shp_params))
-    crc_str = f"{data['OutSum']}:{data['InvId']}:pass2:{shp_part}"
+    crc_str = f"{data['OutSum']}:{data['InvId']}:pass2"
+    if shp_part:
+        crc_str += f":{shp_part}"
     data['SignatureValue'] = hashlib.md5(crc_str.encode()).hexdigest().upper()
     resp = client.post('/payhook', data=data)
     assert resp.json() == 'OK'
@@ -35,10 +37,12 @@ def test_paytoken_persistence(monkeypatch, tmp_path):
     m = reload_main()
     from fastapi.testclient import TestClient
     client = TestClient(m.app)
-    data = {'InvId': '42', 'OutSum': '199', 'Shp_plan': '15'}
+    data = {'InvId': '42', 'OutSum': '199'}
     shp_params = {k: data[k] for k in data if k.startswith('Shp_')}
     shp_part = ':'.join(f"{k}={shp_params[k]}" for k in sorted(shp_params))
-    crc_str = f"{data['OutSum']}:{data['InvId']}:pass2:{shp_part}"
+    crc_str = f"{data['OutSum']}:{data['InvId']}:pass2"
+    if shp_part:
+        crc_str += f":{shp_part}"
     data['SignatureValue'] = hashlib.md5(crc_str.encode()).hexdigest().upper()
     client.post('/payhook', data=data)
 


### PR DESCRIPTION
## Summary
- drop `Shp_plan` from `/payform`
- infer quota in `/payhook` using `OutSum`
- update payment tests for new parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f3fe6de88333ac89447905830701