### PR TITLE
Restore email to Robokassa and add test plan

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -99,7 +99,7 @@ def next_inv_id() -> int:
     return nxt
 
 
-PRICES = {"15": "199", "60": "499"}
+PRICES = {"1": "1", "15": "199", "60": "499"}
 
 
 PROMPT = """
@@ -254,7 +254,9 @@ async def payhook(req: Request):
     if crc != f["SignatureValue"].upper():
         return "bad sign"
     price = f["OutSum"]
-    if price == PRICES["15"]:
+    if price == PRICES["1"]:
+        quota = 1
+    elif price == PRICES["15"]:
         quota = 15
     else:
         quota = 60
@@ -319,6 +321,8 @@ async def payform(request: Request):
         "SignatureValue": sig,
     }
     fields.update(shp_params)
+    if email:
+        fields["Email"] = email
     html = [
         '<form method="POST" action="https://auth.robokassa.ru/Merchant/Index.aspx" id="rk">'
     ]

--- a/frontend/pay.html
+++ b/frontend/pay.html
@@ -13,8 +13,9 @@
   <input type="email" id="email" placeholder="Ваш e-mail" required>
   <label>Тариф:
     <select id="plan">
+      <option value="1" data-price="1">1 переписывание – 1 ₽ (тест)</option>
       <option value="15" data-price="199">15 переписываний – 199 ₽</option>
-      <option value="60" data-price="499">60 переписываний – 499 ₽</option>
+      <option value="60" data-price="499" selected>60 переписываний – 499 ₽</option>
     </select>
   </label>
   <button type="submit">Оплатить</button>

--- a/frontend/pay_test.html
+++ b/frontend/pay_test.html
@@ -14,13 +14,13 @@
   <input type="email" id="email" placeholder="Ваш e-mail" required>
   <label>Тариф:
     <select id="plan">
+      <option value="1" data-price="1">1 переписывание – 1 ₽ (тест)</option>
       <option value="15" data-price="199">15 переписываний – 199 ₽</option>
-      <option value="60" data-price="499">60 переписываний – 499 ₽</option>
+      <option value="60" data-price="499" selected>60 переписываний – 499 ₽</option>
     </select>
   </label>
   <button type="submit">Оплатить</button>
 </form>
-<pre id="rkinfo"></pre>
 <script>
 const form = document.getElementById('pay');
 form.onsubmit = async e => {
@@ -44,15 +44,7 @@ form.onsubmit = async e => {
   // document.getElementById('rk').submit();  // TEST: auto-submit disabled
 };
 
-// Показать pass1/pass2 и формулу CRC
-fetch('https://api.wb6.ru/rkinfo')
-  .then(r => r.json())
-  .then(js => {
-    document.getElementById('rkinfo').textContent =
-      'Pass1: ' + js.pass1 + '\n' +
-      'Pass2: ' + js.pass2 + '\n' +
-      'CRC: ' + js.crc_formula;
-  });
+
 
 // автозагрузка токена после оплаты
 const q = new URLSearchParams(location.search);

--- a/tests/test_payform.py
+++ b/tests/test_payform.py
@@ -36,5 +36,5 @@ def test_payform_crc(monkeypatch):
         crc_str += f":{shp_part}"
     assert fields["SignatureValue"] == hashlib.md5(crc_str.encode()).hexdigest()
     assert "Desc" not in fields
-    assert "Email" not in fields
+    assert fields["Email"] == "1@1.com"
     assert "Shp_plan" not in fields


### PR DESCRIPTION
## Summary
- support one rewrite test plan and restore sending email
- show new option on payment pages
- remove Robokassa credential display from `pay_test.html`
- update tests

## Testing
- `pre-commit run --files backend/main.py frontend/pay.html frontend/pay_test.html tests/test_payform.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886030ed6f883339bdd899010cf0bd9