### PR TITLE
fix payment plan switch

### DIFF
--- a/frontend/pay.html
+++ b/frontend/pay.html
@@ -32,6 +32,8 @@ form.onsubmit = async e => {
     headers: {'Content-Type':'application/json'},
     body: JSON.stringify({plan, email})
   }).then(r => r.json());
+  const old = document.getElementById('rk');
+  if (old) old.remove();
   const div = document.createElement('div');
   div.innerHTML = resp.form;
   document.body.appendChild(div.firstElementChild);

--- a/tests/test_pay_html.py
+++ b/tests/test_pay_html.py
@@ -1,0 +1,10 @@
+import os, re
+import pytest
+
+PAY_HTML = os.path.join(os.path.dirname(__file__), '..', 'frontend', 'pay.html')
+
+
+def test_pay_form_replaced():
+    html = open(PAY_HTML, encoding='utf-8').read()
+    # Ensure previous RK form is removed before inserting a new one
+    assert re.search(r"document.getElementById\('rk'\).*remove()", html, re.S)


### PR DESCRIPTION
## Summary
- remove previous Robokassa form on pay page before creating a new one
- test that pay page script removes stale form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887db66630483338bd93599c24060b3