### PR TITLE
Fix Robokassa price formatting

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -310,6 +310,9 @@ async def payform(request: Request):
     price = PRICES.get(plan)
     if not price:
         return {"error": "BAD_PLAN"}
+    # Robokassa sometimes expects integer sums without trailing zeros.
+    # Normalize the amount to avoid values like "1.00" in the form.
+    price = str(int(float(price)))
     inv = next_inv_id()
     desc = f"{plan} rewrite"
 

--- a/tests/test_payform.py
+++ b/tests/test_payform.py
@@ -38,3 +38,20 @@ def test_payform_crc(monkeypatch):
     assert "Desc" not in fields
     assert fields["Email"] == "1@1.com"
     assert "Shp_plan" not in fields
+
+
+def test_payform_price_one(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.setenv("ROBOKASSA_PASS1", "pass1")
+    app = reload_main().app
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
+
+    resp = client.post("/payform", json={"plan": "1"})
+    fields = {
+        inp["name"]: inp["value"]
+        for inp in BeautifulSoup(resp.json()["form"], "html.parser").find_all("input")
+    }
+
+    assert fields["OutSum"] == "1"


### PR DESCRIPTION
## Summary
- normalize payment sum before generating Robokassa form so that 1 ruble is passed as `1`
- add regression test for 1 ruble plan

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887f4eb84c08333af2934a6cb140e97