### PR TITLE
Remove passwords from Robokassa info endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -340,7 +340,7 @@ async def get_next_inv():
 # Информация для тестовой страницы Robokassa
 @app.get("/rkinfo")
 async def rkinfo():
-    return {"pass1": PASS1, "pass2": PASS2, "crc_formula": CRC_FORMULA}
+    return {"crc_formula": CRC_FORMULA}
 
 
 @app.post("/payform")

--- a/tests/test_rkinfo.py
+++ b/tests/test_rkinfo.py
@@ -18,6 +18,6 @@ def test_rkinfo(monkeypatch):
     client = TestClient(app)
     resp = client.get('/rkinfo')
     js = resp.json()
-    assert js['pass1'] == 'p1'
-    assert js['pass2'] == 'p2'
+    assert 'pass1' not in js
+    assert 'pass2' not in js
     assert 'crc_formula' in js


### PR DESCRIPTION
## Summary
- stop returning PASS1 and PASS2 from `/rkinfo`
- adjust tests to match new response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888a53437b4833380767cf72b398d8e