### PR TITLE
Disable Brotli responses for WB fetch

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -239,6 +239,7 @@ def wb_card_text(url: str, keep_html: bool = False) -> str:
             "User-Agent": ua,
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
             "Accept-Language": os.getenv("WB_LANG", "ru-RU,ru;q=0.9,en-US;q=0.8"),
+            "Accept-Encoding": "gzip, deflate",
             "Connection": "keep-alive",
             "Cache-Control": "no-cache",
             "Pragma": "no-cache",

--- a/test_wb_desc.py
+++ b/test_wb_desc.py
@@ -60,6 +60,7 @@ def get_text(url: str) -> str:
             ),
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             "Accept-Language": os.getenv("WB_LANG", "ru-RU,ru;q=0.9,en-US;q=0.8"),
+            "Accept-Encoding": "gzip, deflate",
             "Connection": "keep-alive",
             "Referer": "https://www.wildberries.ru/",
         }


### PR DESCRIPTION
## Summary
- ensure Wildberries requests prefer gzip or deflate responses
- add `Accept-Encoding` header to `wb_card_text` and `test_wb_desc`

## Testing
- `pre-commit run --files test_wb_desc.py backend/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ba48208d48333988c81471b4644ad