### PR TITLE
Prioritize Wildberries JSON sources before HTML fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ simplejson
 aiohttp>=3.9
 async_timeout
 aiocfscrape>=0.5
+brotli

--- a/tests/test_wb_card_text.py
+++ b/tests/test_wb_card_text.py
@@ -39,6 +39,8 @@ def test_select_correct_product(monkeypatch):
             return Resp(js)
         if url.startswith("https://wbx-content-v2.wbstatic.net/ru"):
             return Resp({})
+        if "static-basket" in url:
+            return Resp({})
         raise AssertionError(url)
 
     class DummySession:
@@ -61,7 +63,7 @@ def test_wbx_content_first(monkeypatch):
     m = reload_main()
     nm = 54321
     js = {
-        "descriptionHtml": "<p>Good desc from wbx that is definitely long enough to use</p>"
+        "descriptionHtml": "<p>Good desc from wbx that is definitely long enough to use and even longer for testing</p>"
     }
 
     class Resp:
@@ -74,6 +76,8 @@ def test_wbx_content_first(monkeypatch):
     def fake_get(url, timeout=10, allow_redirects=True):
         if url.startswith("https://wbx-content-v2.wbstatic.net/ru"):
             return Resp(js)
+        if "static-basket" in url:
+            return Resp({})
         if url.startswith("https://card.wb.ru"):
             return Resp({"data": {"products": [{"id": nm, "description": "wrong"}]}})
         raise AssertionError(url)


### PR DESCRIPTION
## Summary
- Fetch Wildberries descriptions from `wbx-content-v2` then `static-basket` JSON endpoints before calling `card.wb.ru`, leaving HTML as last-resort
- Remove explicit `Accept-Encoding` header and add `brotli` dependency for transparent decompression
- Expand tests to reflect new fetch order and ensure correct product selection

## Testing
- `python test_wb_desc.py` *(fails: Expected snippets missing)*
- `pytest tests/test_wb_card_text.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689bb1f5da688333abae872b140d054d